### PR TITLE
Fix typo in markdown cell of quickstart notebook

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -390,7 +390,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And another case that breaks from the ordering is `Mo`, which is better to keep than much more common `Nb`, and after `Nb` is removed, even better thank keeping the `Ti`, which is the second most common element in the dataset!\n",
+    "And another case that breaks from the ordering is `Mo`, which is better to keep than much more common `Nb`, and after `Nb` is removed, even better than keeping the `Ti`, which is the second most common element in the dataset!\n",
     "\n",
     "Similarly to what we did with `V` vs. `Ta`, we can test how much more data we will have if we remove `Nb` instead of `Mo` by using the `--singleSolution` / `-ss` routine."
    ]


### PR DESCRIPTION
I found a small typo in the Quickstart notebook